### PR TITLE
Add workflows for release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,4 +17,11 @@ jobs:
         uses: actions/checkout@v2
       - name: Build image
         run: make
-
+      - name: Push images to registry
+        if: ${{ github.repository == 'vmware/nsx-container-plugin-operator' && github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        run: |
+          echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+          docker push vmware/nsx-container-plugin-operator:latest

--- a/.github/workflows/build_tag.yml
+++ b/.github/workflows/build_tag.yml
@@ -1,0 +1,21 @@
+name: Build and push a release image
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  build:
+    runs-on: [ubuntu-18.04]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build Operator image and push to registry
+      env:
+        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        TAG: ${{ github.ref }}
+      run: |
+        VERSION="${TAG:10}" make
+        echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+        docker push vmware/nsx-container-plung-operator:"${TAG:10}"

--- a/.github/workflows/upload_release_assets.yml
+++ b/.github/workflows/upload_release_assets.yml
@@ -1,0 +1,28 @@
+name: Upload assets to release
+
+on:
+  release:
+    types:
+      - created
+
+jobs:
+  build:
+    runs-on: [ubuntu-18.04]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build assets
+      env:
+        TAG: ${{ github.ref }}
+      run: |
+        mkdir assets
+        VERSION="${TAG:10}" ./hack/prepare-assets.sh ./assets
+    - name: Upload openshift4 tarball
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./assets/openshift4.tar.gz
+        asset_name: openshift4.tar.gz
+        asset_content_type: application/octet-stream
+

--- a/hack/get-kustomize.sh
+++ b/hack/get-kustomize.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# Copyright © 2021 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+KUSTOMIZE_VERSION="v3.9.1"
+
+# Check if you have kustomize installed, or download it.
+# please note that different versions of kustomize can give different results
+check_or_install_kustomize() {
+    # Check if there is already a kustomize binary in $_BINDIR and if yes, check
+    # if the version matches the expected one.
+    local kustomize="$(PATH=$THIS_DIR command -v kustomize)"
+    if [ -x "$kustomize" ]; then
+        >&2 echo "Found "$kustomize" version "`$kustomize version --short`
+        echo $kustomize
+        return 0
+    fi
+    local kustomize_url="https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz"
+    curl -sLo kustomize.tar.gz "${kustomize_url}" || return 1
+    tar -xzf kustomize.tar.gz || return 1
+    rm -f kustomize.tar.gz
+    echo $kustomize
+    return 0
+}

--- a/hack/prepare-assets.sh
+++ b/hack/prepare-assets.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+# Copyright © 2021 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Usage: VERSION=v1.0.0 ./prepare-assets.sh <output dir>
+
+set -eo pipefail
+
+function echoerr {
+    >&2 echo "$@"
+    exit 1
+}
+
+if [ -z "$VERSION" ]; then
+    echoerr "Environment variable VERSION must be set"
+fi
+
+if [ -z "$1" ]; then
+    echoerr "Argument required: output directory for assets"
+fi
+
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+source ./get-kustomize.sh
+
+kustomize=$(check_or_install_kustomize)
+
+pushd $THIS_DIR/.. > /dev/null
+
+mkdir -p "$1"
+OUTPUT_DIR=$(cd "$1" && pwd)
+
+OPERATOR_IMG_NAME="vmware/nsx-container-plugin-operator"
+OPERATOR_PLATFORMS=(
+    "openshift4"
+    "kubernetes"
+)
+
+for platform in "${OPERATOR_PLATFORMS[@]}"; do
+    mkdir -p ${OUTPUT_DIR}/${platform}
+    cp deploy/${platform}/*.yaml ${OUTPUT_DIR}/${platform}
+    pushd ${OUTPUT_DIR} > /dev/null
+    pushd ${platform} > /dev/null
+    # erase anything that might already be in the kustomization file
+    echo "" > kustomization.yaml
+    $kustomize edit add base operator.yaml
+    $kustomize edit set image ${OPERATOR_IMG_NAME}:${VERSION}
+    $kustomize build > operator_tmp.yaml
+    mv operator_tmp.yaml operator.yaml
+    rm kustomization.yaml
+    popd > /dev/null
+    tar czf ${platform}.tar.gz ${platform}/*.yaml
+    rm -rf ${platform}
+    popd > /dev/null
+done
+
+ls "$OUTPUT_DIR" | cat


### PR DESCRIPTION
This patch adds workflows for automatically pushing new image tags
when a release is made, and uploading operator yaml files as release
assets.

In addition, it modified the build workflow to automatically update
the 'latest' tag for the operator image.